### PR TITLE
Add workaround

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,6 +91,13 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.json'),
           editUrl: 'https://github.com/securecodebox/docusaurus/edit/master/',
+          lastVersion: 'current', 
+          versions: {
+            current: {
+              label: 'Current',
+              path: '',
+            },
+          },
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
Since there is no actual disable flag for displaying version: next, this commit adds a current version which defaults to the default
docs path and uses it as the latest version.