### PR TITLE
Add Hash Over Properties To Finding

### DIFF
--- a/docs/api/finding.md
+++ b/docs/api/finding.md
@@ -50,13 +50,12 @@ Because scanners define different attributes for their findings we need to speci
 ### How The Hash Is calculated
 
 The hash is calculated using the *sha256* algorithm.
-For the calculation of the hash the following properties of all findings have to be included:
+For the calculation of the hash the following properties of all findings are included by default using the *scb-sdk*:
 - name
 - description
 - category
 - osi_layer
 - severity
-- attributes
 - location
 
 :::info

--- a/docs/api/finding.md
+++ b/docs/api/finding.md
@@ -2,6 +2,8 @@
 title: "Finding"
 ---
 
+## Structure Of A Finding
+
 All scanners integrated in the secureCodeBox create findings objects.
 These findings all contain the same set of fields listed in the example below.
 
@@ -35,6 +37,40 @@ These findings all contain the same set of fields listed in the example below.
     "scripts": null
   },
   # Full url with protocol, port, and path if existing
-  "location": "tcp://127.0.0.1:3306"
+  "location": "tcp://127.0.0.1:3306",
+  "finding_hash": "some-sha256-hash"
 }
 ```
+
+## Hashes of Findings and False Positive Handling
+
+To manage false positives and duplicate findings we need to calculate a Hash over each finding for filtering.
+Because scanners define different attributes for their findings we need to specify which attributes are used for the Hash by each parser and each hook that modifies findings.
+
+### How The Hash Is calculated
+
+The hash is calculated using the *sha256* algorithm.
+For the calculation of the hash the following properties of all findings have to be included:
+- name
+- description
+- category
+- osi_layer
+- severity
+- attributes
+- location
+
+:::info
+Notice that `id` is unique for every finding and thus should not be included in the calculation of the hash. Other unique fields need to be ignored as well.
+:::
+
+:::caution
+The `attributes` are different for every scanner as mentioned above.
+This requires that we define which properties are used for the calculation of the hash for each scanner.
+Which fields are included in the hash is defined for each scanner in our documentation (See: [secureCodeBox | Scanners](/docs/scanners)).
+:::
+
+### Where The Hash Is calculated
+
+Because the hash has to be mutable (See: [GitHub/secureCodeBox | ADR-0007](https://github.com/secureCodeBox/secureCodeBox/blob/main/docs/adr/adr_0007.adoc)), we have to calculate this hash everytime we alter a finding.
+This means the hash has to be calculated in the parser for *every* scanner and in *some* of the hooks.
+


### PR DESCRIPTION
For handling false positives and duplicate findings we decided in
ADR-0007 that we would need a hash to identify findings that are equal

In this commit I updated the specication of a finding and added a field
for the hash: finding_hash
This name is WIP and will be changed

See: https://github.com/secureCodeBox/secureCodeBox/blob/main/docs/adr/adr_0007.adoc

Signed-off-by: Yannik Fuhrmeister <yannik.fuhrmeister@iteratec.com>
