### PR TITLE
Extend docs to allow skipping the inclusion of the default cascading rules also for new scanners

### DIFF
--- a/docs/contributing/integrating-a-scanner/templates-dir.md
+++ b/docs/contributing/integrating-a-scanner/templates-dir.md
@@ -37,7 +37,7 @@ Your `cascading-rules.yaml` should look like the following:
 {{ end }}
 ```
 
-In addition, you should add the following to your `yalues.yaml` to allow that the inclusion of the default cascading rules of your scanner can be skipped:
+In addition, you should add the following to your `values.yaml` to allow that the inclusion of the default cascading rules of your scanner can be skipped:
 
 ```yaml
 cascadingRules:

--- a/docs/contributing/integrating-a-scanner/templates-dir.md
+++ b/docs/contributing/integrating-a-scanner/templates-dir.md
@@ -26,11 +26,22 @@ We import them as raw files to avoid these clashes as escaping them is even more
 Your `cascading-rules.yaml` should look like the following:
 
 ```yaml
+# We only want to import the default cascading rules if they are enabled
+{{ if .Values.cascadingRules.enabled }}
 {{ range $path, $_ :=  .Files.Glob  "cascading-rules/*" }}
 # Include File
 {{ $.Files.Get $path }}
 # Separate multiple files
 ---
 {{ end }}
+{{ end }}
+```
+
+In addition, you should add the following to your `yalues.yaml` to allow that the inclusion of the default cascading rules of your scanner can be skipped:
+
+```yaml
+cascadingRules:
+  # cascadingRules.enabled -- Enables or disables the installation of the default cascading rules for this scanner
+  enabled: true
 ```
 


### PR DESCRIPTION
See https://github.com/secureCodeBox/secureCodeBox/issues/316