### PR TITLE
🕸 Extend the Cascading-Scans Hook to generate custom labels or annotations for subsequent scans

### DIFF
--- a/docs/api/crds/cascading-rule.md
+++ b/docs/api/crds/cascading-rule.md
@@ -18,6 +18,18 @@ These objects are compared using a partial deep comparison, meaning that all fie
 If multiple anyOf rules are specified at least one must match the finding. 
 If multiple rules are matching, the CascadingRule will still only create one scan.
 
+
+### ScanLabels & ScanAnnotations (Optional)
+
+Configures additional labels/annotations/ added to each subsequent scan (child). These labels/annotations overwrite any existing labels/annotations. You can use a simple templating scheme to gather details about the parent scan or finding (use `{{variable}}`, see example below). The following variables are available:
+
+- The parent [scan](docs/api/crds/scan) (e.g. `metadata.name`).
+- The related [finding](/docs/api/finding) (e.g. `category`, `attributes.hostname`).
+- Custom variables (prepended with `$.`):
+  - `hostOrIP`: `finding.hostname || finding.ip_address`
+
+If you need more custom variables, please don't hesitate to [create an issue](https://github.com/secureCodeBox/secureCodeBox/issues/new?assignees=&labels=enhancement&template=feature_request.md)!
+
 ### ScanSpec (Required)
 
 Contains the [spec of the scan](/docs/api/crds/scan#specification-spec) which is supposed to be started of the a finding matches the CascadingRule.
@@ -51,6 +63,13 @@ spec:
         attributes:
           service: https
           state: open
+  scanLabels:
+    mynewlabel: {{metadata.name}}
+  scanAnnotations:
+    defectdojo.securecodebox.io/product-name: "{{$.hostOrIP}}"
+    defectdojo.securecodebox.io/product-type-name: "{{metadata.labels.organization}}"
+    defectdojo.securecodebox.io/engagement-name: "{{metadata.name}}"
+    mynewannotation: "{{category}}"
   scanSpec:
     scanType: "zap-baseline"
     parameters: ["-t", "{{attributes.service}}://{{$.hostOrIP}}"]

--- a/docs/api/crds/scan.md
+++ b/docs/api/crds/scan.md
@@ -34,6 +34,8 @@ See:
 
 The cascades config in the scans spec contains [Kubernetes Label Selectors](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#labelselector-v1-meta) which allow you to select which allow you to select which [CascadingRule](https://docs.securecodebox.io/docs/api/crds/cascading-rule) are allowed to be used by the cascading logic.
 
+Furthermore, in the cascade config you can specify whether cascading scan should inherit the parent's labels (`inheritLabels`) and annotations (`inheritAnnotations`). If not specified, the options will be considered as `true`.
+
 To use cascades you'll need to have the [CombinedScan hook](https://docs.securecodebox.io/docs/hooks/cascading-scans) installed.
 
 For an example on how they can be used see the [Scanning Networks HowTo](https://docs.securecodebox.io/docs/how-tos/scanning-networks)
@@ -80,6 +82,8 @@ spec:
     - name: GREETING
       value: "Hello from the secureCodeBox :D"
   cascades:
+    inheritLabels: false
+    inheritAnnotations: true
     matchLabels:
       securecodebox.io/intensive: light
     matchExpression:


### PR DESCRIPTION
This PR updates the documentation to be up-to-date with  [#430](https://github.com/secureCodeBox/secureCodeBox/pull/430) in SCB.