### PR TITLE
Fixing function to copy files from main repo

### DIFF
--- a/scripts/docs.build.js
+++ b/scripts/docs.build.js
@@ -295,18 +295,21 @@ function copyFilesFromMainRepository(src, dst, exclude) {
     console.warn(
       `WARN: ${dstPath.info} already existed and was overwritten.`.warn
     );
-
-    fs.mkdirSync(dstPath);
   }
+
+  console.info(
+    `Create target directory ${dstPath.info}...`.success
+  )
+
+  fs.mkdirSync(dstPath);
 
   fs.readdirSync(srcPath).map((fileName) => {
     if(!exclude.includes(fileName)) {
-      fs.copyFileSync(`${srcPath}/${fileName}`, `${dstPath}/${fileName}`);
-
       console.log(
-        `Copied ${fileName.help} at ${dstPath.info}`.success
+        `Copy ${fileName.info} to ${dstPath.info}...`.success
       );
+
+      fs.copyFileSync(`${srcPath}/${fileName}`, `${dstPath}/${fileName}`);
     }
   });
 }
-


### PR DESCRIPTION
The function failed to create the destination directory because we
did the creation inside the conditional block which is only executed
when it already exists.

This patch moves the directory create out of the block. Also improves
logging a little bit: Writing waht is done before the action is better
because you have the log statement also if the executed action fails
and exit the code.

Signed-off-by: Sven Strittmatter <sven.strittmatter@iteratec.com>