### PR TITLE
Rename lurcher to lurker

### DIFF
--- a/docs/api/crds/scan-type.md
+++ b/docs/api/crds/scan-type.md
@@ -26,7 +26,7 @@ The type is used to determine which parser would be used to handle this result f
 The `location` field describes from where the result file can be extracted.
 Absolute path on the containers file system.
 
-Must be located in `/home/securecodebox/` so that the result is reachable by the secureCodeBox Lurcher sidecar which performs the actual extraction of the result.
+Must be located in `/home/securecodebox/` so that the result is reachable by the secureCodeBox Lurker sidecar which performs the actual extraction of the result.
 E.g. `/home/securecodebox/nmap-results.xml`
 
 ### JobTemplate (Required)

--- a/docs/getting-started/uninstallation.md
+++ b/docs/getting-started/uninstallation.md
@@ -29,7 +29,7 @@ kubectl delete cascadingrules.cascading.securecodebox.io nmap-hostscan
 
 ## Uninstall the Operator and Its Roles, ServiceAccounts and RoleBindings
 
-To uninstall the operator it is not enough to delete the operator via `helm` because the operator creates Roles, ServiceAccounts  and RoleBindings used by parsers, lurchers and hooks in every namespace where scanners and hooks are executed. These cannot be uninstalled via helm because they cannot be referenced via Kubernetes OwnerReferences.
+To uninstall the operator it is not enough to delete the operator via `helm` because the operator creates Roles, ServiceAccounts  and RoleBindings used by parsers, lurkers and hooks in every namespace where scanners and hooks are executed. These cannot be uninstalled via helm because they cannot be referenced via Kubernetes OwnerReferences.
 
 Make sure you delete all scans and uninstall all scanners/hooks before uninstalling the operator to avoid problems.
 First delete the namespace for the operator:
@@ -46,36 +46,36 @@ The given examples are valid only for scanners that were executed in the default
 To list the ServiceAccounts, Roles and RoleBings that were created by the operator you can execute the flowing command:
 
 ```bash {1}
-kubectl get roles,rolebindings,serviceaccounts lurcher parser
+kubectl get roles,rolebindings,serviceaccounts lurker parser
 NAME                                     CREATED AT
-role.rbac.authorization.k8s.io/lurcher   2020-10-14T11:15:38Z
+role.rbac.authorization.k8s.io/lurker   2020-10-14T11:15:38Z
 role.rbac.authorization.k8s.io/parser    2020-10-14T11:17:54Z
 
 NAME                                            ROLE           AGE
-rolebinding.rbac.authorization.k8s.io/lurcher   Role/lurcher   85m
+rolebinding.rbac.authorization.k8s.io/lurker   Role/lurker   85m
 rolebinding.rbac.authorization.k8s.io/parser    Role/parser    83m
 
 NAME                     SECRETS   AGE
-serviceaccount/lurcher   1         85m
+serviceaccount/lurker   1         85m
 serviceaccount/parser    1         83m
 ```
 
-To delete the Roles for lurcher and parser you can execute the following command:
+To delete the Roles for lurker and parser you can execute the following command:
 
 ```bash
-kubectl delete roles lurcher parser
+kubectl delete roles lurker parser
 ```
 
-To delete the RoleBindings for lurcher and parser you can execute:
+To delete the RoleBindings for lurker and parser you can execute:
 
 ```bash
-kubectl delete rolebindings lurcher parser
+kubectl delete rolebindings lurker parser
 ```
 
-To delete the ServiceAccounts for lurcher and parser you can execute:
+To delete the ServiceAccounts for lurker and parser you can execute:
 
 ```bash
-kubectl delete serviceaccounts lurcher parser
+kubectl delete serviceaccounts lurker parser
 ```
 
 ### Delete CRDs

--- a/src/puml/2020-11-04-why-securecodebox-version-2/architecture-v2.puml
+++ b/src/puml/2020-11-04-why-securecodebox-version-2/architecture-v2.puml
@@ -21,9 +21,9 @@ node "Kubernetes" {
 
   package "Job" as zap_scan {
     [ZAP] as zap <<Container>>
-    [Lurcher] as zap_lurcher <<Sidecar>>
-    zap -left-> zap_lurcher : output
-    zap_lurcher -down-> S3 : store raw
+    [Lurker] as zap_lurker <<Sidecar>>
+    zap -left-> zap_lurker : output
+    zap_lurker -down-> S3 : store raw
   }
 
   zap .up.> sut : scan


### PR DESCRIPTION
Renames `lurcher` to `lurker` to fix this long lasting typo.