### PR TITLE
Fix Broken Findings Download Links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ src/integrations.js
 docs/scanners/
 docs/hooks/
 docs/guides/
+static/findings
 
 # Used by bin/create_post.sh
 .author_meta

--- a/scripts/docs.build.js
+++ b/scripts/docs.build.js
@@ -236,16 +236,16 @@ function copyFindingsForDownload(filePath) {
       dirNames[dirNames.indexOf("examples") - 1] +
       "-" +
       dirNames[dirNames.indexOf("examples") + 1],
-    targetPath = `public/findings/${name}-findings.yaml`;
+    targetPath = `/${config.findingsDir}/${name}-findings.yaml`;
 
-  if (!fs.existsSync("public")) {
-    fs.mkdirSync("public/");
+  if (!fs.existsSync("static")) {
+    fs.mkdirSync("static/");
   }
-  if (!fs.existsSync("public/findings")) {
-    fs.mkdirSync("public/findings/");
+  if (!fs.existsSync(`static/${config.findingsDir}`)) {
+    fs.mkdirSync(`static/${config.findingsDir}`);
   }
 
-  fs.copyFileSync(filePath, targetPath);
+  fs.copyFileSync(filePath, "static"+targetPath);
   console.log(`SUCCESS: Created download link for ${name.info}.`.success);
 
   return targetPath;

--- a/scripts/utils/config.js
+++ b/scripts/utils/config.js
@@ -8,7 +8,7 @@ const docsConfig = {
     targetPath: "docs", // This needs to be 'docs' for the docusaurus build, but you may specify a 'docs/<subdirectory>'
     srcDirs: ["scanners", "hooks"], // Directory names, relative to the root directory of the github project, containing the subdirectories with documentation
     sizeLimit: 500000, // Limit of file size, most importantly used for large findings.
-    findingsDir: "public/findings", // Directory for large findings which exceeded sizeLimit
+    findingsDir: "findings", // Directory for large findings which exceeded sizeLimit
 
     // Configures files which will be copied from docsConfig.repository.
     // This is an array of config maps. The map has the properties

--- a/scripts/utils/scannerReadme.mustache
+++ b/scripts/utils/scannerReadme.mustache
@@ -39,7 +39,7 @@ values={[
 <TabItem value="findings">
 
 {{#limitReached}}
-The findings are too large to display, you may download <a target="_blank" href="pathname:///{{{value}}}" download> the file.</a>
+The findings are too large to display, you may download [the file]({{{value}}}).
 {{/limitReached}}
 {{^limitReached}}
 ```yaml

--- a/scripts/utils/scannerReadme.mustache
+++ b/scripts/utils/scannerReadme.mustache
@@ -39,7 +39,7 @@ values={[
 <TabItem value="findings">
 
 {{#limitReached}}
-The findings are too large to display, you may download <a target="_blank" href="{{{/value}}}" download> the file.</a>
+The findings are too large to display, you may download <a target="_blank" href="pathname:///{{{value}}}" download> the file.</a>
 {{/limitReached}}
 {{^limitReached}}
 ```yaml

--- a/scripts/utils/scannerReadme.mustache
+++ b/scripts/utils/scannerReadme.mustache
@@ -39,7 +39,7 @@ values={[
 <TabItem value="findings">
 
 {{#limitReached}}
-The findings are too large to display, you may download <a target="_blank" href="/{{{value}}}" download> the file.</a>
+The findings are too large to display, you may download <a target="_blank" href="{{{/value}}}" download> the file.</a>
 {{/limitReached}}
 {{^limitReached}}
 ```yaml


### PR DESCRIPTION
Docusaurus currently views the findings download links (for trivy and zap) as broken and npm run build therefore fails.

This PR solves the issue.

Signed-off-by: Johannes Zahn <johannes.zahn@iteratec.com>