### PR TITLE
Fix Frontmatter Manipulation

### DIFF
--- a/scripts/utils/scannerReadme.mustache
+++ b/scripts/utils/scannerReadme.mustache
@@ -3,7 +3,6 @@
 
   SPDX-License-Identifier: Apache-2.0
 }}
-
 {{{ readme }}}
 
 


### PR DESCRIPTION
Fixes the broken Frontmatter that was introduced by a newline in the mustache template before the inserted markdown content.