### PR TITLE
Adding a how-to use your local docker images to the "Integrate a new scanner" tutorial

### DIFF
--- a/docs/contributing/integrating-a-scanner/values.yaml.md
+++ b/docs/contributing/integrating-a-scanner/values.yaml.md
@@ -141,7 +141,7 @@ these steps:
 1. Create your parser and scanner Dockerfiles
 2. Change the tags in values.yaml file like this:
 ```yaml
- parser:
+parser:
   image:
     repository: your-custom-parser
     pullPolicy: IfNotPresent

--- a/docs/contributing/integrating-a-scanner/values.yaml.md
+++ b/docs/contributing/integrating-a-scanner/values.yaml.md
@@ -141,14 +141,14 @@ these steps:
 1. Create your parser and scanner Dockerfiles
 2. Change the tags in values.yaml file like this:
 ```yaml
-   parser:
-     image:
-      repository: your-custom-parser
-      pullPolicy: IfNotPresent
-  scanner:
-     image:
-      repository: your-custom-scanner
-      pullPolicy: IfNotPresent
+ parser:
+  image:
+    repository: your-custom-parser
+    pullPolicy: IfNotPresent
+scanner:
+  image:
+    repository: your-custom-scanner
+    pullPolicy: IfNotPresent
 ```
 3. Build your parser, using the **version** from Chart.yaml (e.g. v3.1.0-alpha1):
 ```bash

--- a/docs/contributing/integrating-a-scanner/values.yaml.md
+++ b/docs/contributing/integrating-a-scanner/values.yaml.md
@@ -133,13 +133,13 @@ Optional additional Containers started with each scanJob (see: [Init Containers 
 Optional securityContext set on scanner container (see: [Configure a Security Context for a Pod or Container | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)).
 
 
-### Using local images
+## Using local images
 
-If you are integrating a new scanner and want to test your scanner and parser image from a local build, you can use
-the following steps:
+If you are integrating a new scanner and want to test your scanner and parser image from a local build, you can follow
+these steps:
 
 1. Create your parser and scanner Dockerfiles
-2. Change the values.yaml file like this:
+2. Change the tags in values.yaml file like this:
 ```yaml
    parser:
      image:


### PR DESCRIPTION
This PR adds a new section that explains step-by-step how to use your own local docker images for parser and scanners. This is an important step to integrate your own scanner and test it without pushing to the dockerhub repository. 