### PR TITLE
Fixes for Tutorial: How-To Network Scanning

### DIFF
--- a/docs/how-tos/scanning-networks.md
+++ b/docs/how-tos/scanning-networks.md
@@ -17,7 +17,7 @@ For the sake of the tutorial, we assume that you have your Kubernetes cluster al
 If not done yet, **install the nmap scanner:**
 
 ```bash
-helm upgrade --install nmap ./scanners/nmap/
+helm upgrade --install nmap secureCodeBox/nmap
 ```
 
 Now we also need the **declarative subsequent scan hook** (if not installed yet):
@@ -44,7 +44,7 @@ kubectl create secret generic --from-file users.txt --from-file passwords.txt nc
 Lastly, we now **install Ncrack** and configure the scanType to mount our secret, so that we get access to the username and password files via the mount path `/ncrack/`:
 
 ```bash
-cat <<EOF | helm upgrade --install ncrack ./scanners/ncrack --values -
+cat <<EOF | helm upgrade --install ncrack secureCodeBox/ncrack --values -
 scannerJob:
   extraVolumes:
     - name: ncrack-lists

--- a/docs/how-tos/scanning-networks.md
+++ b/docs/how-tos/scanning-networks.md
@@ -20,10 +20,10 @@ If not done yet, **install the nmap scanner:**
 helm upgrade --install nmap secureCodeBox/nmap
 ```
 
-Now we also need the **declarative subsequent scan hook** (if not installed yet):
+Now we also need the **cascading-scans hook** (if not installed yet):
 
 ```bash
-helm upgrade --install dssh ./hooks/declarative-subsequent-scans/
+helm upgrade --install cascading-scans secureCodeBox/cascading-scans
 ```
 
 Finally, setting up **Ncrack** is a little trickier though. Ncrack uses files with lists of usernames and passwords to brute-force an authentication. In its default configuration, the scanner will check for all combinations of usernames and passwords provided by our lists. You can use your own existing files or just create two **dummy files** for the purpose of the tutorial:


### PR DESCRIPTION
This PR adds some small fixes to the [How-To Network Scanning Tutorial](https://docs.securecodebox.io/docs/how-tos/scanning-networks).

Fixes:
* Replaced local install of scanners/hooks with installation from repo
* Renamed outdated declarative subsequent scan hook to cascading scans
