### PR TITLE
Fixes broken titles in light mode

### DIFF
--- a/src/css/styles.module.scss
+++ b/src/css/styles.module.scss
@@ -22,6 +22,9 @@
   @include lg {
     padding: 4rem 0;
   }
+  h1 {
+  color: white;
+  }
 }
 
 .description {
@@ -53,9 +56,6 @@ h2 {
   margin: 20px 0 0;
 }
 
-h1 {
-  color: white;
-}
 
 .dark {
   background-color: whitesmoke;


### PR DESCRIPTION
White Color overwrite for h1 headers is now only done for the herobanner in the landing page.