### PR TITLE
Update values.yaml documentation to match SCBv3 syntax

### DIFF
--- a/docs/contributing/integrating-a-scanner/values.yaml.md
+++ b/docs/contributing/integrating-a-scanner/values.yaml.md
@@ -12,34 +12,59 @@ In the following we will describe the important fields.
 The final `values.yaml` will look something like this:
 
 ```yaml
-image:
-  repository: docker.io/securecodebox/scanner-nmap
-  tag: null
+# Define the image and settings for the parser container
+parser:
+  image:
+    # parser.image.repository -- Parser image repository
+    repository: docker.io/securecodebox/parser-nmap
+    # parser.image.tag -- Parser image tag
+    # @default -- defaults to the charts version
+    tag: null
 
-parserImage:
-  repository: docker.io/securecodebox/parser-nmap
-  tag: null
-
-scannerJob:
+  # parser.ttlSecondsAfterFinished -- seconds after which the kubernetes job for the parser will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
   ttlSecondsAfterFinished: null
-
-  resources: {}
-     resources:
-       requests:
-         memory: "256Mi"
-         cpu: "250m"
-       limits:
-         memory: "512Mi"
-         cpu: "500m"
-
+  # @default -- 3
+  backoffLimit: 3
+  # parser.env -- Optional environment variables mapped into each parseJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
   env: []
 
+# Do the same for the scanner containers
+scanner:
+  image:
+    # scanner.image.repository -- Container Image to run the scan
+    repository: docker.io/securecodebox/parser-nmap
+    # scanner.image.tag -- defaults to the charts appVersion
+    tag: null
+
+  # scanner.ttlSecondsAfterFinished -- seconds after which the kubernetes job for the scanner will be deleted. Requires the Kubernetes TTLAfterFinished controller: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/
+  ttlSecondsAfterFinished: null
+  # scannerJob.backoffLimit -- There are situations where you want to fail a scan Job after some amount of retries due to a logical error in configuration etc. To do so, set backoffLimit to specify the number of retries before considering a scan Job as failed. (see: https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy)
+  # @default -- 3
+  backoffLimit: 3
+
+  # scanner.resources -- CPU/memory resource requests/limits (see: https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/, https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/)
+  resources: {}
+  #   resources:
+  #     requests:
+  #       memory: "256Mi"
+  #       cpu: "250m"
+  #     limits:
+  #       memory: "512Mi"
+  #       cpu: "500m"
+
+  # scanner.env -- Optional environment variables mapped into each scanJob (see: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+  env: []
+
+  # scanner.extraVolumes -- Optional Volumes mapped into each scanJob (see: https://kubernetes.io/docs/concepts/storage/volumes/)
   extraVolumes: []
 
+  # scanner.extraVolumeMounts -- Optional VolumeMounts mapped into each scanJob (see: https://kubernetes.io/docs/concepts/storage/volumes/)
   extraVolumeMounts: []
 
+  # scanner.extraContainers -- Optional additional Containers started with each scanJob (see: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
   extraContainers: []
 
+  # scanner.securityContext -- Optional securityContext set on scanner container (see: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
   securityContext:
     runAsNonRoot: true
     readOnlyRootFilesystem: true
@@ -50,48 +75,32 @@ scannerJob:
         - all
 ```
 
-## image
+## scanner and parser
 
-The `image` field contains the container image and tag used for the scanner.
-This could be the official image of the scanner but in some cases a custom image is needed.
-Usually the `tag` of the image is `null` and will default to the charts `appVersion`.
+The two top-level fields `scanner` and `parser` define the containers and settings for the scanner and parser, respectively. 
+All fields below are common for both scanner and parser.
+
+### image
+
+The `image` field contains the container image and tag used for the scanner or parser.
+For the scanner, this could be the official image of the scanner or a custom image, if one is needed.
+Usually the `tag` of the image is `null` and will default to the charts `appVersion` (for the scanner) or `version` (for the parser).
 See below how to use a local docker image.
-For WPScan the official image can be used so the `image` field looks like this:
+For WPScan the official image can be used so the `image` fields for scanner and parser may look like this:
 
 ```yaml
-image:
-  repository: wpscanteam/wpscan
-  tag: null
+scanner:
+  image:
+    repository: wpscanteam/wpscan
+    tag: null
+  # ...
+
+parser:
+  image:
+    repository: docker.io/securecodebox/parser-wpscan
+    tag: null
+  # ...
 ```
-
-## parserImage
-
-The `parserImage` field specifies the container image with the parser for the scanner.
-This will always be a custom image containing the Parser SDK and the parser (see Parser SDK).
-Like in `image` the `tag` will default to the charts `appVersion` and should be `null` in `values.yaml`.
-For WPScan `parserImage` looks like this:
-
-```yaml
-parserImage:
-  repository: docker.io/securecodebox/parser-wpscan
-  tag: null
-```
-
-## scannerJob
-
-`scannerJob` defines multiple properties for the Scan Job including resources, environment variables, volumes and security context.
-A basic `scannerJob` could look like the following.
-
-```yaml
-scannerJob:
-  ttlSecondsAfterFinished: null
-  resources: {}
-  env: []
-  extraVolumes: []
-  extraVolumeMounts: []
-  extraContainers: []
-  securityContext: {}
-  ```
 
 ### ttlSecondsAfterFinished
 
@@ -99,7 +108,7 @@ Defines how long the scanner job after finishing will be available (see: [TTL Co
 
 ### resources
 
-The `resources` field can limit or request resources for the scan job (see: [Managing Resources For Containers | Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)).
+The `resources` field can limit or request resources for the scan / parse job (see: [Managing Resources For Containers | Kubernetes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)).
 A basic example could be the following:
 
 ```yaml
@@ -114,23 +123,23 @@ resources:
 
 ### env
 
-Optional environment variables mapped into each scanJob (see: [Define Environment Variables for a Container | Kubernetes](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)).
+Optional environment variables mapped into the job (see: [Define Environment Variables for a Container | Kubernetes](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)).
 
 ### extraVolumes
 
-Optional Volumes mapped into each scanJob (see: [Volumes | Kubernetes](https://kubernetes.io/docs/concepts/storage/volumes/)).
+Optional Volumes mapped into the job (see: [Volumes | Kubernetes](https://kubernetes.io/docs/concepts/storage/volumes/)).
 
 ### extraVolumeMounts
 
-Optional VolumeMounts mapped into each scanJob (see: [Volumes | Kubernetes](https://kubernetes.io/docs/concepts/storage/volumes/)).
+Optional VolumeMounts mapped into the job (see: [Volumes | Kubernetes](https://kubernetes.io/docs/concepts/storage/volumes/)).
 
 ### extraContainers
 
-Optional additional Containers started with each scanJob (see: [Init Containers | Kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)).
+Optional additional Containers started with the job (see: [Init Containers | Kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)).
 
 ### securityContext
 
-Optional securityContext set on scanner container (see: [Configure a Security Context for a Pod or Container | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)).
+Optional securityContext set on the container (see: [Configure a Security Context for a Pod or Container | Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)).
 
 
 ## Using local images


### PR DESCRIPTION
The current version of the documentation for the values.yaml file still uses SCBv2 syntax, which is no longer used (see [UPGRADING.md](https://github.com/secureCodeBox/secureCodeBox/blob/main/UPGRADING.md#restructured-the-securecodebox-helmcharts-to-introduce-more-consistency-in-helmchart-values) in the main repo). I have updated this to the best of my knowledge, but someone more familiar with the syntax should take another look at this. In particular, I am unsure if all fields can indeed be set for both scanner and parser images, or if some are exclusive to one or the other.