### PR TITLE
Document which fields are templated for cascading scans

### DIFF
--- a/docs/api/crds/cascading-rule.md
+++ b/docs/api/crds/cascading-rule.md
@@ -38,7 +38,7 @@ If you need more custom variables, please don't hesitate to [create an issue](ht
 
 Contains the [spec of the scan](/docs/api/crds/scan#specification-spec) which is supposed to be started of the a finding matches the CascadingRule.
 
-The `scanType`, `parameters`, and `env`, as well as the `command` and `env` of any included `initContainers`,  can use [mustache](https://mustache.github.io/mustache.5.html) templates to refer to fields of the finding the CascadingRule has been applied to. The finding is passed in directly into the mustache templating call, so that fields of the findings can be directly referenced. E.g. the location can be directly referred to by: `{{location}}`.
+The `scanType`, `parameters`, values specified in `env` variables, as well as the `command` and `env` of any included `initContainers`,  can use [mustache](https://mustache.github.io/mustache.5.html) templates to refer to fields of the finding the CascadingRule has been applied to. The finding is passed in directly into the mustache templating call, so that fields of the findings can be directly referenced. E.g. the location can be directly referred to by: `{{location}}`.
 
 For convenience a helper object has been added to the mustache call under the `$` shorthand.
 


### PR DESCRIPTION
Documentation for the changes made in https://github.com/secureCodeBox/secureCodeBox/pull/773: Adding the ability to template environmental variables in cascading scans.