### PR TITLE
Symlink license file into toplevel dir

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+LICENSES/Apache-2.0.txt


### PR DESCRIPTION
We use the Reuse tool for license validation. This tool require
that all project licenses are located into the directory LICENSES.

OTOH GitHub does not recognize licenses in this sub direcotry. I
softlinked it into the top level directory, so that GitHub may
recognize the license automatically.

Signed-off-by: Sven Strittmatter <sven.strittmatter@iteratec.com>