### PR TITLE
Fix social preview image for SAST article

### DIFF
--- a/blog/2021-10-27-sast-scanning.md
+++ b/blog/2021-10-27-sast-scanning.md
@@ -14,7 +14,7 @@ tags:
   - cascading scans
   - case study
 description: This post gives an introduction to using the new SAST functionality of secureCodeBox to find a malicious dependency
-image: /img/blog/2021-09-07-notes.jpg
+image: /img/blog/2021-10-27-magnifyingglass.jpg
 ---
 
 ![A magnifying glass pointed at a laptop keyboard](/img/blog/2021-10-27-magnifyingglass.jpg)


### PR DESCRIPTION
I forgot to change the URL for the social media preview image from the previous blog article, this commit fixes that.