### PR TITLE
Add missing ADRs to sidebar

### DIFF
--- a/scripts/utils/config.js
+++ b/scripts/utils/config.js
@@ -69,6 +69,8 @@ const docsConfig = {
             "architecture/adr/adr_0005",
             "architecture/adr/adr_0006",
             "architecture/adr/adr_0007",
+            "architecture/adr/adr_0008",
+            "architecture/adr/adr_0009",
           ],
         },
       ],


### PR DESCRIPTION
The list of ADRs is currently not autogenerated. This PR adds ADR 8 and 9 to the sidebar to fix the current inconsistency, long-term this should be autogenerated, see #92 for discussion.