### PR TITLE
Add Autodiscovery how to article

### DIFF
--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -8,33 +8,33 @@ sidebar_position: 6
 ---
 
 ## Introduction
-It is possible to automatically create scheduled scans for kubernetes entities with the secureCodeBox autodiscovery. There are two availble modes that can be activated if needed. A _service_ and a _container_ autodiscovery.
+It is possible to automatically create scheduled scans for kubernetes entities with the secureCodeBox autodiscovery. There are two available modes that can be activated if needed. A _service_ and a _container_ autodiscovery.
 
 ### Container Autodiscovery
-The container autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options)  for each unique container image in a kubernetes namespace.  
+The container autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options)  for each unique container image in a kubernetes namespace.
 It is currently disabled by default and must be enabled manually.
 
-Assume that a namespace contains two pods that run a `nginx V1.5` container. The container autodiscovery will only create a single scheduled scan for the _nginx_ containers, as both are identical.  
-When a third pod inside the namespace is started running a `nginx V1.6` container, the container autodiscovery will create an additional scheduled scan for the `nginx V1.6` container, as it is not scanned at this point in time. The container autodiscovery will look at the specific version number of each container when it determiens if the a container is scanned.
-When both `nginx V1.5` pods get deleted the corresponding scheduled scans will also be automatically deleted because the specific container image is no longer present in the namespace.  
+Assume that a namespace contains two pods that run a `nginx V1.5` container. The container autodiscovery will only create a single scheduled scan for the _nginx_ containers, as both are identical.
+When a third pod inside the namespace is started running a `nginx V1.6` container, the container autodiscovery will create an additional scheduled scan for the `nginx V1.6` container, as it is not scanned at this point in time. The container autodiscovery will look at the specific version number of each container when it determines if the a container is scanned.
+When both `nginx V1.5` pods get deleted the corresponding scheduled scans will also be automatically deleted because the specific container image is no longer present in the namespace.
 The scheduled scan for the `nginx V1.6` container will not be deleted, as it is still running in the namespace.
 
-In other words: The container autodiscovery will create a single scheduled scan for each unique container image (taking specific version number into account) in a given namespace.
+In other words: The container autodiscovery will create a single scheduled scan for each unique container image (taking the specific version number into account) in a given namespace.
 
 If a pod consists of multiple containers, the above described logic will be applied to each container individually.
 
 ### Service Autodiscovery
-The service autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options) for each kubernetetes service it detects.  
+The service autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options) for each kubernetes service it detects.
 The service autodiscovery is enabled by default but can be disabled manually.
 
-The service autodiscovery will ignore services where the underlying pods do not serve http(s). It does this by simply checking for open ports `80, 443, 3000, 5000, 8000, 8443, 8080`. It is also sufficient to name the ports `http` or `https` when a different port is used than the ports specified above.  
+The service autodiscovery will ignore services where the underlying pods do not serve http(s). It does this by simply checking for open ports `80, 443, 3000, 5000, 8000, 8443, 8080`. It is also sufficient to name the ports `http` or `https` when a different port is used than the ports specified above.
 Every service using a different port or not naming the port accordingly will be ignored.
 
 ## Setup
 For the sake of the tutorial, it will be assumed that a Kubernetes cluster and the SCB operator is already up and running. If not, check out the [installation](/docs/getting-started/installation/) tutorial for more information.
-This tutorial will use the `default` and `securecodebox-system` namespace!
+This tutorial will use the `default` and `securecodebox-system` namespace.
 
-First install `zap-andvanced` and `trivy`:
+First install the `zap-advanced` and `trivy` scan types:
 ```bash
 helm upgrade --install zap-advanced secureCodeBox/zap-advanced
 helm upgrade --install trivy secureCodeBox/trivy
@@ -45,7 +45,7 @@ Then install the SCB autodiscovery (container autodiscovery is explicitly enable
 helm upgrade --namespace securecodebox-system --install auto-discovery-kubernetes secureCodeBox/auto-discovery-kubernetes --set config.containerAutoDiscovery.enabled=true
 ```
 
-Then annotate the `default` namespace to enable the autodiscovery in that default. There are three so called `resourceInclusionModes`. These controll which resources the autodiscovery will scan.
+Then annotate the `default` namespace to enable the autodiscovery feature for the namespace. There are three so called `resourceInclusionModes`. These control which resources the autodiscovery will scan.
 - enabled-per-namespace (default)
 - enabled-per-resource
 - scan-all (scans every service and/ or container in the whole cluster!)
@@ -58,7 +58,7 @@ Then install juiceshop as a demo target:
 helm upgrade --install juice-shop secureCodeBox/juice-shop
 ```
 
-The autodiscovery will create two scheduled scans after some time. One for the juiceshop servcie using `zap`, and one for the juiceship container using `trivy`:
+The autodiscovery will create two scheduled scans after some time. One for the juiceshop service using `zap`, and one for the juiceshop container using `trivy`:
 ```bash
 $ kubectl get scheduledscans
 NAME                                                             TYPE                INTERVAL   FINDINGS
@@ -79,7 +79,7 @@ juice-shop2-service-port-3000                                    zap-advanced-sc
 scan-juice-shop-at-350cf9a6ea37138b987a3968d046e61bcd3bb18d2ec   trivy               168h0m0s   
 ```
 
-Delete both juicehop deployments.
+Delete both juiceshop deployments.
 ```bash
 kubectl delete deployment,service juice-shop juice-shop2
 ```

--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -13,7 +13,7 @@ Currently the SCB autodiscovery supports two modes that can be enabled independe
 This tutorial will explain both modes and will give a practical step by step example one can follow.
 
 ### Container Autodiscovery
-The container autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options)  for each unique container image in a kubernetes namespace.
+The container autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options)  for each unique container image in a kubernetes namespace. Currently it is only possible to scan public container images!  
 It is currently disabled by default and must be enabled manually.
 
 Assume that a namespace contains two pods that run a `nginx V1.5` container. The container autodiscovery will only create a single scheduled scan for the _nginx_ containers, as both are identical.
@@ -26,7 +26,7 @@ In other words: The container autodiscovery will create a single scheduled scan 
 If a pod consists of multiple containers, the above described logic will be applied to each container individually.
 
 ### Service Autodiscovery
-The service autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options) for each kubernetes service it detects.
+The service autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options) for each kubernetes service it detects. (It is possible to scan APIs that require authentication, see [ZAP Advanced](../scanners/zap-advanced.md) documentation).  
 The service autodiscovery is enabled by default but can be disabled manually.
 
 The service autodiscovery will ignore services where the underlying pods do not serve http(s). It does this by simply checking for open ports `80, 443, 3000, 5000, 8000, 8443, 8080`. It is also sufficient to name the ports `http` or `https` when a different port is used than the ports specified above.

--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -95,6 +95,9 @@ $ kubectl get scheduledscans
 No resources found in default namespace.
 ```
 ## Config
+The scanType and scan parameters can be changed by providing `containerAutodiscovery.scanConfig.scanType` and `containerAutodiscovery.scanConfig.parameters` (replace `containerAutodiscovery` with `serviceAutodiscovery` to change scanType and scan parameters for the service autodiscovery).  
+The scan parameters support go templating extended with [_sprig_](https://github.com/Masterminds/sprig). An example for go templating would be the default parameters for the container autodiscovery: `{{ .ImageID }}`. _ImageID_ is the imageID of the scanned container, example: `docker.io/bkimminich/juice-shop@sha256:350cf9a6ea37138b987a3968d046e61bcd3bb18d2ec95290cfc6901bd6013826`
+
 All config options are automatically updated in the [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) in the Github repository.
 
 

--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -86,3 +86,5 @@ After some time all scheduled scans will be automatically deleted.
 $ kubectl get scheduledscans
 No resources found in default namespace.
 ```
+## Config
+All config options are automatically updated in the [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) in the Github repository.

--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -97,3 +97,6 @@ No resources found in default namespace.
 ## Config
 All config options are automatically updated in the [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) in the Github repository.
 
+
+## Conclusion
+This article explained the functionality of the SCB autodiscovery and gave a step by step example which gave a brief overview on how to use the autodiscovery.

--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -1,0 +1,64 @@
+---
+# SPDX-FileCopyrightText: the secureCodeBox authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+title: "Automatically run scans with Autodiscovery"
+sidebar_position: 6
+---
+
+## Introduction
+It is possible to automatically create scheduled scans for kubernetes entities with the secureCodeBox autodiscovery. There are two availble modes that can be activated if needed. A _service_ and a _container_ autodiscovery.
+
+#### Container Autodiscovery
+The container autodiscovery will create a scheduled scan with the given parameters (see configuration options below) for each unique container image in a kubernetes namespace.  
+It is currently disabled by default and must be enabled manually.
+
+Assume that a namespace contains two pods that run a _npm __V1.5__ _ container. The container autodiscovery will only create a single scheduled scan for the _npm_ containers, as both are identical.  
+When a third pod inside the namespace is started running a _npm_ __V1.6__ container, the container autodiscovery will create an additional scheduled scan for the _npm __V1.6__ _ container, as it is new and not scanned at this point in time.  
+When both _npm __V1.5__ _ pods get deleted the corresponding scheduled scans will also be automatically deleted because the specific container image is no longer present in the namespace.
+
+In other words: The container autodiscovery will create a single scheduled scan for each unique container image (taking specific version number into account) in a given namespace.
+
+If a pod consists of multiple containers, the above described logic will be applied to each container individually.
+
+#### Service Autodiscovery
+The service autodiscovery will create a scheduled scan with the given parameters (see configuration options below) for each kubernetetes service it detects.  
+The service autodiscovery is enabled by default but can be disabled manually.
+
+The service autodiscovery will ignore services where the underlying pods do not serve http(s). It checks for open ports `80, 443, 3000, 5000, 8000, 8443, 8080`. It is also sufficient to name the ports `http` or `https` when a different port is used than the ports specified above.
+
+## Setup
+For the sake of the tutorial, it will be assumed that a Kubernetes cluster and the SCB operator is already up and running. If not, check out the [installation](/docs/getting-started/installation/) for more information.
+This tutorial will use the `default` and `securecodebox-system` namespace!
+
+First install `zap-andvanced`and `trivy`:
+```bash
+helm upgrade --install zap-advanced secureCodeBox/zap-advanced
+helm upgrade --install trivy secureCodeBox/trivy
+```
+
+Then install the SCB autodiscovery (ContainerAutodiscovery is explicitly enabled in this example):
+```bash
+helm upgrade --namespace securecodebox-system --install auto-discovery-kubernetes secureCodeBox/auto-discovery-kubernetes --set config.containerAutoDiscovery.enabled=true
+```
+
+Then annotate the namespace so that the autodiscovery searches the namespace (see section about resourceInclusionMode):
+```bash
+kubectl annotate namespace default auto-discovery.securecodebox.io/enabled=true
+```
+
+Then install juiceshop as a demo target:
+```bash
+helm upgrade --install juice-shop secureCodeBox/juice-shop
+```
+
+The autodiscovery will create two scheduled scans. One for the juiceshop servcie using `zap`, and one for the juiceship container using `trivy`:
+```bash
+$ kubectl get scheduled scans
+NAME                                                             TYPE                INTERVAL   FINDINGS
+juice-shop-service-port-3000                                     zap-advanced-scan   168h0m0s   
+scan-juice-shop-at-350cf9a6ea37138b987a3968d046e61bcd3bb18d2ec   trivy               168h0m0s   
+
+```
+

--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -3,14 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-title: "Automatically Run Scans with Autodiscovery"
+title: "Automatically Scan Your Cluster with Autodiscovery"
 sidebar_position: 6
 ---
 
-## Introduction
-The secureCodeBox offers so called _scheduled scans_. As the name suggests these _scheduled scans_ run regularly based of a predefined time interval. The SCB autodiscovery automates the process of setting up _scheduled scans_ by automatically creating _scheduled scans_ for Kubernetes entities inside a cluster. The autodiscovery will observe the scanned Kubernetes entities over their whole lifecycle. It will automatically create, update and delete scans when necessary.
-Currently the SCB autodiscovery supports two modes that can be enabled independently: A _service_ and a _container_ autodiscovery.
-This tutorial will explain both modes and will give a practical step by step example you can follow.
+## Introduction 
+The secureCodeBox allows you to set up regular scans of your infrastructure using _scheduled scans_. As the name suggests, these _scheduled scans_ run based on a predefined time interval. However, it can be cumbersome to set this up for your entire infrastructure. If you are operating your infrastructure inside a Kubernetes cluster, there is an easier way to do this: The SCB autodiscovery automates the process of setting up _scheduled scans_ by creating _scheduled scans_ for Kubernetes entities inside a cluster.
+
+The autodiscovery will observe the scanned Kubernetes entities over their whole lifecycle. It will automatically create, update and delete scans when necessary. Currently the SCB autodiscovery supports two modes that can be enabled independently: A _service_ and a _container_ autodiscovery. This tutorial will explain both modes and will give a practical step by step example you can follow.
 
 ### Container Autodiscovery
 The container autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options) for each unique container image in a Kubernetes namespace. Currently it is only possible to scan public container images.  

--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -14,9 +14,9 @@ It is possible to automatically create scheduled scans for kubernetes entities w
 The container autodiscovery will create a scheduled scan with the given parameters (see configuration options below) for each unique container image in a kubernetes namespace.  
 It is currently disabled by default and must be enabled manually.
 
-Assume that a namespace contains two pods that run a _npm __V1.5__ _ container. The container autodiscovery will only create a single scheduled scan for the _npm_ containers, as both are identical.  
-When a third pod inside the namespace is started running a _npm_ __V1.6__ container, the container autodiscovery will create an additional scheduled scan for the _npm __V1.6__ _ container, as it is new and not scanned at this point in time.  
-When both _npm __V1.5__ _ pods get deleted the corresponding scheduled scans will also be automatically deleted because the specific container image is no longer present in the namespace.
+Assume that a namespace contains two pods that run a `nginx V1.5` container. The container autodiscovery will only create a single scheduled scan for the _nginx_ containers, as both are identical.  
+When a third pod inside the namespace is started running a `nginx V1.6` container, the container autodiscovery will create an additional scheduled scan for the `nginx V1.6` container, as it is new and not scanned at this point in time.  
+When both `nginx V1.5` pods get deleted the corresponding scheduled scans will also be automatically deleted because the specific container image is no longer present in the namespace.
 
 In other words: The container autodiscovery will create a single scheduled scan for each unique container image (taking specific version number into account) in a given namespace.
 

--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -8,7 +8,9 @@ sidebar_position: 6
 ---
 
 ## Introduction
-It is possible to automatically create scheduled scans for kubernetes entities with the secureCodeBox autodiscovery. There are two available modes that can be activated if needed. A _service_ and a _container_ autodiscovery.
+The securecodebox offers so called _scheduled scans_. As the name suggests these _scheduled scans_ run regularly based of a predefined time interval. The SCB autodiscovery automates the process of _scheduled scans_ by automatically creating _scheduled scans_ for kubernetes entities inside a cluster. The autodiscovery will observe the scanned kubernetes entities over their whole lifecycle. It will automatically create, update and delete scans when necessary.  
+Currently the SCB autodiscovery supports two modes that can be enabled independently: A _service_ and a _container_ autodiscovery.  
+This tutorial will explain both modes and will give a practical step by step example one can follow.
 
 ### Container Autodiscovery
 The container autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options)  for each unique container image in a kubernetes namespace.
@@ -94,3 +96,4 @@ No resources found in default namespace.
 ```
 ## Config
 All config options are automatically updated in the [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) in the Github repository.
+

--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -45,10 +45,14 @@ Then install the SCB autodiscovery (container autodiscovery is explicitly enable
 helm upgrade --namespace securecodebox-system --install auto-discovery-kubernetes secureCodeBox/auto-discovery-kubernetes --set config.containerAutoDiscovery.enabled=true
 ```
 
-Then annotate the `default` namespace to enable the autodiscovery feature for the namespace. There are three so called `resourceInclusionModes`. These control which resources the autodiscovery will scan.
+ There are three so called `resourceInclusionModes`. These control which resources the autodiscovery will scan.
 - enabled-per-namespace (default)
 - enabled-per-resource
 - scan-all (scans every service and/ or container in the whole cluster!)
+
+Depending on the _resourceInclusionMode_ one has to annotate each namespace or kubernetes resource for which the autodiscovery should be enabled. If `scan-all` is used nothing has to be annotated as everything will be scanned.  
+This tutorial will use `enabled-per-namespace` as _ressourceInclusionMode_ which is the default.
+Annotate the `default` namespace to enable the autodiscovery feature for the namespace.
 ```bash
 kubectl annotate namespace default auto-discovery.securecodebox.io/enabled=true
 ```

--- a/docs/how-tos/autodiscovery.md
+++ b/docs/how-tos/autodiscovery.md
@@ -11,7 +11,7 @@ sidebar_position: 6
 It is possible to automatically create scheduled scans for kubernetes entities with the secureCodeBox autodiscovery. There are two availble modes that can be activated if needed. A _service_ and a _container_ autodiscovery.
 
 #### Container Autodiscovery
-The container autodiscovery will create a scheduled scan with the given parameters (see configuration options below) for each unique container image in a kubernetes namespace.  
+The container autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options)  for each unique container image in a kubernetes namespace.  
 It is currently disabled by default and must be enabled manually.
 
 Assume that a namespace contains two pods that run a `nginx V1.5` container. The container autodiscovery will only create a single scheduled scan for the _nginx_ containers, as both are identical.  
@@ -23,7 +23,7 @@ In other words: The container autodiscovery will create a single scheduled scan 
 If a pod consists of multiple containers, the above described logic will be applied to each container individually.
 
 #### Service Autodiscovery
-The service autodiscovery will create a scheduled scan with the given parameters (see configuration options below) for each kubernetetes service it detects.  
+The service autodiscovery will create a scheduled scan with the given parameters (see [readme](https://github.com/secureCodeBox/secureCodeBox/blob/main/auto-discovery/kubernetes/README.md) for config options) for each kubernetetes service it detects.  
 The service autodiscovery is enabled by default but can be disabled manually.
 
 The service autodiscovery will ignore services where the underlying pods do not serve http(s). It checks for open ports `80, 443, 3000, 5000, 8000, 8443, 8080`. It is also sufficient to name the ports `http` or `https` when a different port is used than the ports specified above.


### PR DESCRIPTION
This PR adds a how to article describing the Autodiscovery.
This How to describes the Autodiscovery with this bug fix PR from the main securecodebox repo (https://github.com/secureCodeBox/secureCodeBox/pull/1070) included. So only merge this PR when the bug PR from the main repo is merged, so that our documentation is in sync