### PR TITLE
Fixing endpoint address of AWS S3 

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -62,7 +62,7 @@ minio:
 s3:
   enabled: true
   # update the region to match the location of your bucket
-  endpoint: "s3-eu-west-1.amazonaws.com"
+  endpoint: "s3.eu-west-1.amazonaws.com"
   bucket: "your-own-securecodebox-bucket-name"
   # Name to a k8s secret with 'accesskey' and 'secretkey' as attributes in the same namespace as this release
   # Example creation via kubectl:


### PR DESCRIPTION
Fixing incorrect endpoint "s3-eu-west" to [correct](https://docs.aws.amazon.com/general/latest/gr/s3.html) "s3.eu-west" in Getting started -> Installation. 
It is the only occurrence in both repositories as far as I can see.

(Closes [#1099](https://github.com/secureCodeBox/secureCodeBox/issues/1099))