### PR TITLE
:books: Adding community contribution criteria and lists

### DIFF
--- a/docs/community-features/_category_.json
+++ b/docs/community-features/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Community Features",
+  "position": 8
+}

--- a/docs/community-features/scanners-and-hooks.md
+++ b/docs/community-features/scanners-and-hooks.md
@@ -1,0 +1,27 @@
+---
+# SPDX-FileCopyrightText: the secureCodeBox authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+title: "Community Scanners and Hooks"
+sidebar_label: Scanners and Hooks
+path: "docs/community-features/scanners-and-hooks"
+sidebar_position: 0
+---
+
+:::note
+Thanks to our community, there are even more features available for the *secureCodeBox* than in the main branch
+and official releases. This site gives an overview about all community features that are currently known to us.
+If you want your feature to get listed here or to have it removed, please 
+[contact us](mailto:securecodebox@iteratec.com). Features added to this list have been checked at least once by the core
+development team to fit the general concept of the *secureCodeBox*. However, we cannot guarantee that they are 
+compatible with the latest release. You have to use them on your own responsibility and risk.
+:::
+
+## Scanners
+
+* [Grype by RealAlphaMan](https://github.com/RealAlphaMan/grype-scantype-scb) - Added 16.05.2022
+
+## Hooks
+
+> ✍ **Following...**

--- a/docs/community-features/windows-scanners.md
+++ b/docs/community-features/windows-scanners.md
@@ -5,7 +5,8 @@
 
 title: "Windows Scanners"
 sidebar_label: Windows Scanners
-path: "docs/experimental/windows-scanners"
+path: "docs/community-features/windows-scanners"
+sidebar_position: 1
 ---
 
 # Integrating Windows™ Scanners into the secureCodeBox

--- a/docs/contributing/contribution-criteria.md
+++ b/docs/contributing/contribution-criteria.md
@@ -18,20 +18,21 @@ your PR will fall. Creating an [issue](https://github.com/secureCodeBox/secureCo
 is a good way to get an overview of what has to be done and get feedback early! To create an issue is also a 
 must-have for any change that takes longer than one hour to complete.
 
-### Merge by default
+### Merge after approving review
 
-Given that the formal acceptance criteria (see below) are met, we will merge the following sorts of PRs by default:
+Given that the formal acceptance criteria (see below) are met, we will merge the following sorts of PRs without 
+additional internal discussion:
 * Bug fixes
 * Documentation enhancements
 * Maintenance work such as code style or typo fixes
-* Updates to existing features (operator, scans, hooks, auto-discovery, tests)
 
 ### Merge only after team decision
 
-PRs other than the ones that we merge by default will be discussed by the core developer team. We will stay in close
+PRs other than the ones above will be discussed by the core developer team. We will stay in close
 contact with you regarding the decision process. If you think that your PR falls into that category, it might be
 worth to [get in touch](https://www.securecodebox.io/blog/2021/09/07/how-we-work#get-engaged) before you get started.
 
+* Updates to existing features (operator, scans, hooks, auto-discovery, tests)
 * New features (especially scanners, hooks, tests)
 * Breaking changes (especially operator, auto-discovery)
 

--- a/docs/contributing/contribution-criteria.md
+++ b/docs/contributing/contribution-criteria.md
@@ -30,7 +30,7 @@ Given that the formal acceptance criteria (see below) are met, we will merge the
 
 PRs other than the ones that we merge by default will be discussed by the core developer team. We will stay in close
 contact with you regarding the decision process. If you think that your PR falls into that category, it might be
-worth to [get in touch](/blog/2021-09-07-how-we-work) before you get started.
+worth to [get in touch](https://www.securecodebox.io/blog/2021/09/07/how-we-work#get-engaged) before you get started.
 
 * New features (especially scanners, hooks, tests)
 * Breaking changes (especially operator, auto-discovery)

--- a/docs/contributing/contribution-criteria.md
+++ b/docs/contributing/contribution-criteria.md
@@ -1,0 +1,86 @@
+---
+# SPDX-FileCopyrightText: the secureCodeBox authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+title: "Contribution criteria"
+sidebar_position: 0
+---
+
+Thank you for your interest in contributing to the Open Source repository of the *secureCodeBox*. Your effort is much
+appreciated! On this site, we list the requirements to get your pull request (PR) merged to the main branch. 
+For more information about contributing in general, please refer to our [contributing file](https://github.com/secureCodeBox/secureCodeBox/blob/45f6979f5ca0c81c25384543f7434127c7a48c7f/CONTRIBUTING.md).
+
+## Content related criteria
+
+To avoid any frustration on your side before you even got started, please decide into which category the content of
+your PR will fall. Creating an [issue](https://github.com/secureCodeBox/secureCodeBox/issues) in our main repository
+is a good way to get an overview of what has to be done and get feedback early! To create an issue is also a 
+must-have for any change that takes longer than one hour to complete.
+
+### Merge by default
+
+Given that the formal acceptance criteria (see below) are met, we will merge the following sorts of PRs by default:
+* Bug fixes
+* Documentation enhancements
+* Maintenance work such as code style or typo fixes
+* Updates to existing features (operator, scans, hooks, auto-discovery, tests)
+
+### Merge only after team decision
+
+PRs other than the ones that we merge by default will be discussed by the core developer team. We will stay in close
+contact with you regarding the decision process. If you think that your PR falls into that category, it might be
+worth to [get in touch](/blog/2021-09-07-how-we-work#get-engaged) before you get started.
+
+* New features (especially scanners, hooks, tests)
+* Breaking changes (especially operator, auto-discovery)
+
+The reason behind why your PR can possibly get rejected could be that we might not have enough capacity to maintain your 
+PR in the future, that it might be too specific (e.g. introducing a scanner that has similar functionality as an
+already existing one) or that it does not fit into the current overall development strategy of the *secureCodeBox*. 
+If that is the case, you might still want to add your new feature to our 
+[custom community contributions](/docs/community-features/scanners-and-hooks).
+
+## Formal acceptance criteria
+
+If your PR meets the content-related acceptance criteria above, you then only have to make sure that our formal criteria
+are also met. Here is an overview about them:
+
+* DCO compliance
+* All checks completed successfully
+* Changes approved
+* Optional: Verified commits
+
+### DCO compliance
+
+Each commit must contain the signed-off-by tag with your real name and email address at the bottom:
+
+```text
+Signed-off-by: gordon shumway <alf@melmak.com>
+```
+
+Committing with `git commit -s` will add the sign-off at the end of the commit message automatically for you.
+In addition, if it is your first time to contribute, please also add your name and e-mail to the 
+[list of contributors](https://github.com/secureCodeBox/secureCodeBox/blob/45f6979f5ca0c81c25384543f7434127c7a48c7f/CONTRIBUTORS.md).
+You can simply do that as a change in your PR.
+
+### All checks completed successfully
+
+Please make sure that all tests run successfully on your forked branch. If it is your first time contributing,
+our GitHub workflow has to be approved by a core developer (which is usually done as soon as possible). 
+Please feel free to open a *draft PR* if you need early feedback here.
+
+### Changes approved
+
+If you are done with your PR, you can request a review from one of our core team developers. The developer (or 
+another member of the team that is free) will then review your PR and might request changes. Once everything is fixed
+and looks good, your PR will be approved and get merged as soon as possible. Thank you for contributing! :)
+
+### Optional: Verified commits
+
+Please make sure that you are using a method to 
+[sign your commits on GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+This, however, is a strict requirement only for our core developer team. But you can increase the trustworthiness 
+of all your contributions to any open source project by signing your commits.
+"Signing your commits" is not to be confused with the "Sign-off" (see DCO compliance above), which is mandatory for
+legal reasons.

--- a/docs/contributing/contribution-criteria.md
+++ b/docs/contributing/contribution-criteria.md
@@ -30,7 +30,7 @@ Given that the formal acceptance criteria (see below) are met, we will merge the
 
 PRs other than the ones that we merge by default will be discussed by the core developer team. We will stay in close
 contact with you regarding the decision process. If you think that your PR falls into that category, it might be
-worth to [get in touch](/blog/2021-09-07-how-we-work#get-engaged) before you get started.
+worth to [get in touch](/blog/2021-09-07-how-we-work) before you get started.
 
 * New features (especially scanners, hooks, tests)
 * Breaking changes (especially operator, auto-discovery)

--- a/docs/experimental/_category_.json
+++ b/docs/experimental/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Experimental",
-  "position": 8
-}


### PR DESCRIPTION
Once applied, this PR will:

* Add a "contribution criteria" page to the "Contributing" section. It explains content-related and formal criteria in order to get a PR merged to the main branch.
* Rename the "experimental" section to "community features" and add a page "community scanners and hooks" there. It contains a note that all features listed there are reviewed once by our core developer team but not maintained by us. Features the "Grype" scanner by @RealAlphaMan as a first community contribution.

I decided to combine these to enhancements into one PR, because they are very closely related.