### PR TITLE
Adding helm repo update note to troubleshooting

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -37,6 +37,11 @@ helm upgrade --install nmap secureCodeBox/nmap
 
 ### Error: ImagePullBackOff
 
+* Try to upgrade your helm repository before installing the scanner (it is a good idea to do this periodically):
+```bash
+helm repo update secureCodeBox
+```
+
 * Check that you actually use a scanner from the repo instead of a local one:
 ```bash
 # Local:

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -37,7 +37,7 @@ helm upgrade --install nmap secureCodeBox/nmap
 
 ### Error: ImagePullBackOff
 
-* Try to upgrade your helm repository before installing the scanner (it is a good idea to do this periodically):
+* Try to update your helm repository before installing the scanner (it is a good idea to do this periodically):
 ```bash
 helm repo update secureCodeBox
 ```


### PR DESCRIPTION
Once applied, this PR adds the following hint to the troubleshooting document:
```
helm repo update secureCodeBox
```

It could potentially save some users a ton of time, especially if they are not so familiar with *helm*.
