### PR TITLE
Renamed the telemetry file so it is autogenerated in the sidebar by docusurus

### DIFF
--- a/docs/09-telemetry.md
+++ b/docs/09-telemetry.md
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+sidebar_label: Telemetry
 title: "secureCodeBox Telemetry Data"
 ---
 


### PR DESCRIPTION
09- means that it takes position 9 in the sidebar
Reference: https://docusaurus.io/docs/2.0.1/sidebar/autogenerated