### PR TITLE
Add notes about supported CPU architectures

### DIFF
--- a/docs/how-tos/persistence-storage.md
+++ b/docs/how-tos/persistence-storage.md
@@ -45,6 +45,11 @@ we install the *secureCodeBox* and the [DefectDojo hook](https://www.securecodeb
 
 (General, more detailed instructions can be found [here](https://github.com/DefectDojo/django-DefectDojo/blob/dev/readme-docs/KUBERNETES.md))
 
+:::info
+At the moment **DefectDojo does not provide a Docker image for arm64**. As a workaround you can run a local instance
+of DefectDojo (see [Troubleshooting](#troubleshooting)).
+:::
+
 Using *minikube* (for kind clusters see instructions below):
 ```bash
 # Download DefectDojo repo

--- a/scripts/utils/scannerReadme.mustache
+++ b/scripts/utils/scannerReadme.mustache
@@ -5,6 +5,17 @@
 }}
 {{{ readme }}}
 
+{{#hasImageTypes}}
+
+## CPU architectures
+
+The scanner is currently supported for these CPU architectures:
+
+{{#imageTypes}}
+- {{.}}
+{{/imageTypes}}
+
+{{/hasImageTypes}}
 
 {{#hasExamples}}
 ## Examples


### PR DESCRIPTION
Contains two parts:

- a new note about the DefectDojo image
- syncs the info about supported architectures for a scanner from the `Chart.yaml` file in the secureCodeBox repo when building the documentation.