### PR TITLE
Expand and update hook integration docs

### DIFF
--- a/docs/contributing/integrating-a-hook/dockerfile.md
+++ b/docs/contributing/integrating-a-hook/dockerfile.md
@@ -11,14 +11,15 @@ The Dockerfile for a hook looks like the following.
 If you use the provided *hook-sdk*, you won't need to apply any changes to it.
 
 ```Dockerfile
+ARG namespace
 ARG baseImageTag
-FROM node:12-alpine as build
+FROM node:18-alpine as build
 RUN mkdir -p /home/app
 WORKDIR /home/app
 COPY package.json package-lock.json ./
 RUN npm ci --production
 
-FROM securecodebox/hook-sdk-nodejs:${baseImageTag:-latest}
+FROM ${namespace:-securecodebox}/hook-sdk-nodejs:${baseImageTag:-latest}
 WORKDIR /home/app/hook-wrapper/hook/
 COPY --from=build --chown=app:app /home/app/node_modules/ ./node_modules/
 COPY --chown=app:app ./hook.js ./hook.js

--- a/docs/contributing/integrating-a-hook/hook.md
+++ b/docs/contributing/integrating-a-hook/hook.md
@@ -23,7 +23,6 @@ As parameters for `handle()` the _hook-sdk_ provides the following:
   - [updateRawResults()](#updaterawresults)
   - [updateFindings()](#updatefindings)
   - [scan](#scan)
-  - [Example](#example)
 - [hook.test.js](#hooktestjs)
 
 ### getRawResults()
@@ -145,6 +144,44 @@ async function handle({
 ```
 
 ### scan
+
+The scan object contains information about the scan resource in Kubernetes.
+The information is equivalent to what you get by running `kubectl get scan/<name> -o json`
+
+Example (shortened):
+
+```json
+{
+  "apiVersion": "execution.securecodebox.io/v1",
+  "kind": "Scan",
+  "metadata": {
+      "creationTimestamp": "2023-09-01T15:43:13Z",
+      "generation": 2,
+      "name": "trivy-image-sbom-juice-shop",
+      "namespace": "integration-tests",
+      ...
+  },
+  "spec": {
+      "parameters": [
+          "bkimminich/juice-shop:v15.0.0"
+      ],
+      "resourceMode": "namespaceLocal",
+      "resources": {},
+      "scanType": "trivy-image-sbom"
+  },
+  "status": {
+      "findingDownloadLink": "http://securecodebox-operator-minio...",
+      "findingHeadLink": "http://securecodebox-operator-minio...",
+      "findings": { ... },
+      "orderedHookStatuses": [ ... ],
+      "rawResultDownloadLink": "http://securecodebox-operator-minio...",
+      "rawResultFile": "sbom-cyclonedx.json",
+      "rawResultHeadLink": "http://securecodebox-operator-minio...",
+      "rawResultType": "sbom-cyclonedx",
+      "state": "HookProcessing"
+  }
+}
+```
 
 ### Example
 

--- a/docs/contributing/integrating-a-hook/readme-and-helm-docs.md
+++ b/docs/contributing/integrating-a-hook/readme-and-helm-docs.md
@@ -42,3 +42,4 @@ helm upgrade --install gwh secureCodeBox/generic-webhook --set webhookUrl="http:
 ```
 
 If you want to generate the `README.md` out of your `.helm-docs.gotmpl` locally, you can use `helm-docs` (see: [https://github.com/norwoodj/helm-docs/](https://github.com/norwoodj/helm-docs/)).
+You can then update all `README.md` files automatically by running `make docs` from the top level directory.

--- a/docs/contributing/integrating-a-hook/templates-dir.md
+++ b/docs/contributing/integrating-a-hook/templates-dir.md
@@ -18,7 +18,7 @@ apiVersion: "execution.securecodebox.io/v1"
 kind: ScanCompletionHook
 metadata:
   name: {{ include "generic-webhook.fullname" . }}
-  labels: {{ - include "generic-webhook.labels" . | nindent 4 }}
+  labels: {{- include "generic-webhook.labels" . | nindent 4 }}
 spec:
   type: ReadOnly
   image: "{{ .Values.hook.image.repository }}:{{ .Values.hook.image.tag | default .Chart.Version }}"
@@ -26,6 +26,6 @@ spec:
   env:
     - name: WEBHOOK_URL
       value: {{ .Values.webhookUrl | quote }}
-  affinity: {{ - toYaml .Values.hook.affinity | nindent 4 }}
-  tolerations: {{ - toYaml .Values.hook.tolerations | nindent 4 }}
+  affinity: {{- toYaml .Values.hook.affinity | nindent 4 }}
+  tolerations: {{- toYaml .Values.hook.tolerations | nindent 4 }}
 ```


### PR DESCRIPTION
- Use current node LTS in example `Dockerfile`
- explain the `scan`parameter in JavaScript hooks
- fix template helm docs syntax
- add `make`target to generate docs

Closes #349